### PR TITLE
chore: make headers sticky

### DIFF
--- a/_site/css/style.css
+++ b/_site/css/style.css
@@ -2,7 +2,7 @@
     box-sizing: border-box;
     text-align: left;
    }
-  
+
   body {
     background-color: #fff;
     color: #2d2d35;
@@ -11,7 +11,7 @@
     line-height: 1.7;
     text-rendering: optimizeLegibility;
   }
-  
+
   main {
     padding: 1rem;
   }
@@ -39,12 +39,12 @@
 
   th[scope="col"] {
     border-top-left-radius: 1rem;
-    border-top-right-radius: 1rem;    
+    border-top-right-radius: 1rem;
   }
 
   th[scope="row"] {
     border-top-left-radius: 1rem;
-    border-bottom-left-radius: 1rem;    
+    border-bottom-left-radius: 1rem;
   }
 
   tbody tr:nth-child(odd) td,
@@ -67,13 +67,30 @@
   }
 
   tbody tr:nth-child(odd) td p {
-    background-color: #fff;    
+    background-color: #fff;
   }
 
   tbody tr:nth-child(even) td p {
-    background-color: #f2f2f2;    
+    background-color: #f2f2f2;
   }
 
   tbody td {
       border-left: 1px solid;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    background: white;
+    box-shadow: 0 -1px 0 0 black inset;
+  }
+
+  thead th:first-child {
+    box-shadow: none;
+    background: none;
+  }
+
+  thead th[scope="col"] {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
   }

--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
     box-sizing: border-box;
     text-align: left;
    }
-  
+
   body {
     background-color: #fff;
     color: #2d2d35;
@@ -11,7 +11,7 @@
     line-height: 1.7;
     text-rendering: optimizeLegibility;
   }
-  
+
   main {
     padding: 1rem;
   }
@@ -39,12 +39,12 @@
 
   th[scope="col"] {
     border-top-left-radius: 1rem;
-    border-top-right-radius: 1rem;    
+    border-top-right-radius: 1rem;
   }
 
   th[scope="row"] {
     border-top-left-radius: 1rem;
-    border-bottom-left-radius: 1rem;    
+    border-bottom-left-radius: 1rem;
   }
 
   tbody tr:nth-child(odd) td,
@@ -67,13 +67,30 @@
   }
 
   tbody tr:nth-child(odd) td p {
-    background-color: #fff;    
+    background-color: #fff;
   }
 
   tbody tr:nth-child(even) td p {
-    background-color: #f2f2f2;    
+    background-color: #f2f2f2;
   }
 
   tbody td {
       border-left: 1px solid;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    background: white;
+    box-shadow: 0 -1px 0 0 black inset;
+  }
+
+  thead th:first-child {
+    box-shadow: none;
+    background: none;
+  }
+
+  thead th[scope="col"] {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
   }


### PR DESCRIPTION
Makes the table headers sticky, so its (hopefully) easier to see which column applies to its 'level' (ernstig, zeer ernstig, etc) while scrolling through the measures

![Oct-14-2020 13-07-04](https://user-images.githubusercontent.com/17054057/95981328-c1503900-0e1e-11eb-8cc0-b5bf807ac0a4.gif)
